### PR TITLE
Fixes test in Python 3 + Pip >= 8.1.1

### DIFF
--- a/pkgversion/__init__.py
+++ b/pkgversion/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from .pkgversion import (
-    get_git_repo_dir, get_version, list_requirements, pep440_version,
-    write_setup_py,
+    get_git_repo_dir, get_version, list_requirements, PIP_PEP503_ENFORCED, pep440_version,
+    pep503_package_name, write_setup_py,
 )

--- a/tests/test_pkgversion.py
+++ b/tests/test_pkgversion.py
@@ -77,6 +77,11 @@ class TestPkgversion(object):
             match = re.match('([^\s<=>]+)([\s<=>].+)?', item)
             yield "".join(filter(None, (pep503_package_name(match.groups()[0]), match.groups()[1])))
 
+    def test_pep503_name(self):
+        test = 'some_package.name'
+        expected = 'some-package-name'
+        assert pep503_package_name(test) == expected
+
     def test_get_git_repo_dir(self):
         assert os.path.isdir(get_git_repo_dir())
         assert os.path.isdir(os.path.join(get_git_repo_dir(), '.git'))

--- a/tests/test_pkgversion.py
+++ b/tests/test_pkgversion.py
@@ -13,8 +13,8 @@ import re
 from subprocess import PIPE, Popen
 
 from pkgversion import (
-    get_git_repo_dir, get_version, list_requirements, pep440_version,
-    write_setup_py,
+    get_git_repo_dir, get_version, list_requirements, PIP_PEP503_ENFORCED, pep440_version,
+    pep503_package_name, write_setup_py,
 )
 
 requirements_file = os.path.join(
@@ -67,7 +67,15 @@ class TestPkgversion(object):
             'ranged_version<=2,>=1.0', 'url', 'unversioned_url',
             'editable'
         ]
+        if PIP_PEP503_ENFORCED:
+            expected = list(self._enforce_pep503_names(expected))
+
         assert actual == expected
+
+    def _enforce_pep503_names(self, requirements):
+        for item in requirements:
+            match = re.match('([^\s<=>]+)([\s<=>].+)?', item)
+            yield "".join(filter(None, (pep503_package_name(match.groups()[0]), match.groups()[1])))
 
     def test_get_git_repo_dir(self):
         assert os.path.isdir(get_git_repo_dir())


### PR DESCRIPTION
pip now asks for PEP503-normalized names when requesting the simple page from an index. Previously “-” and ”.” would be allowed but with the new normalization ”.” is substituted with “-”. Now pip install zope.interface triggers a request to +simple/zope-interface

So Python 3 tests are failing on such configuration, and that is what this PR fixes