### PR TITLE
FIX: Pip 20 support for importing PipSession

### DIFF
--- a/pkgversion/pkgversion.py
+++ b/pkgversion/pkgversion.py
@@ -5,12 +5,17 @@ import re
 from subprocess import PIPE, Popen
 
 try:
-    from pip._internal.download import PipSession
+    from pip._internal.network.session import PipSession
     from pip._internal.req import parse_requirements
 except ImportError:
-    # Output expected ImportErrors for PIP < 10.
-    from pip.download import PipSession
-    from pip.req import parse_requirements
+    # Output expected ImportErrors for PIP < 20.
+    try:
+        from pip._internal.download import PipSession
+        from pip._internal.req import parse_requirements
+    except ImportError:
+        # Output expected ImportErrors for PIP < 10.
+        from pip.download import PipSession
+        from pip.req import parse_requirements
 
 
 setup_py_template = """

--- a/tests/test_pkgversion.py
+++ b/tests/test_pkgversion.py
@@ -97,7 +97,7 @@ class TestPkgversion(object):
                 Popen(command, stdout=PIPE, cwd=str(tmpdir)).communicate()
 
             expected_import = "^from setuptools import setup$"
-            expected_setup = "^setup\(\*\*(.*)\)$"
+            expected_setup = "^setup\(\*\*(.*)\)$"  # noqa: W605
 
             write_setup_py(
                 install_requires=['test']

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,7 @@ addopts=--tb=short
 
 [tox]
 envlist =
-    py27-{pip9,pip10}
-    py35-{pip9,pip10}
-    py36-{pip9,pip10}
+    py{27,35,36}-pip{9,10,20}
     cov
     isort-check
     isort-fix
@@ -13,15 +11,6 @@ envlist =
     docs
 
 skipsdist = true
-
-basepython =
-    py27-{pip9,pip10}: python2.7
-    py35-{pip9,pip10}: python3.5
-    py36-{pip9,pip10}: python3.6
-    cov: python3.6
-deps =
-    -rrequirements/requirements-base.txt
-    -rrequirements/requirements-testing.txt
 
 [testenv:cov]
 basepython= python3.6
@@ -31,27 +20,16 @@ deps =
     -rrequirements/requirements-base.txt
     -rrequirements/requirements-testing.txt
 
-[general]
+[testenv]
 commands =
      py.test tests
 deps =
+    pip9: pip>=9,<10
+    pip10: pip>=10,<20
+    pip20: pip>=20
     -rrequirements/requirements-base.txt
     -rrequirements/requirements-testing.txt
 
-[testenv:py27-{pip9,pip10}]
-basepython = python2.7
-commands =
-    {[general]commands}
-
-[testenv:py35-{pip9,pip10}]
-basepython = python3.5
-commands =
-   {[general]commands}
-
-[testenv:py36-{pip9,pip10}]
-basepython = python3.6
-commands =
-    {[general]commands}
 
 ##
 # Flake8 linting


### PR DESCRIPTION
FIX: Pip 20 support for importing PipSession

Tox wasn't correctly testing for me. Config slightly simplified and pip20+ added.
