### PR TITLE
FIX: Pip 20+ support and fix tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kpndigital/tox:py27_py35
+FROM kpndigital/tox:py27_py37_py38
 
 WORKDIR /app
 

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ clean: pyclean docsclean
 	@rm -rf venv
 
 venv:
-	@python3.6 -m venv venv
+	@python3.8 -m venv venv
 	@$(PIP) install -U "pip>=7.0" -q
 	@$(PIP) install -r $(DEPS)
 

--- a/pkgversion/pkgversion.py
+++ b/pkgversion/pkgversion.py
@@ -4,13 +4,16 @@ import pprint
 import re
 from subprocess import PIPE, Popen
 
-try:
-    from pip._internal.download import PipSession
+try:  # pip20+
+    from pip._internal.network.session import PipSession
     from pip._internal.req import parse_requirements
 except ImportError:
-    # Output expected ImportErrors for PIP < 10.
-    from pip.download import PipSession
-    from pip.req import parse_requirements
+    try:  # pip10+
+        from pip._internal.download import PipSession
+        from pip._internal.req import parse_requirements
+    except ImportError:   # pip<10
+        from pip.download import PipSession
+        from pip.req import parse_requirements
 
 
 setup_py_template = """

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,47 @@
 
 from setuptools import setup
-setup(**{'name': 'pkgversion', 'author': 'Niels Lensink', 'author_email': 'niels@elements.nl', 'include_package_data': True, 'long_description': 'Python pkgversion\n=================\n\n.. image:: https://secure.travis-ci.org/kpn-digital/py-pkgversion.svg?branch=master\n    :target:  http://travis-ci.org/kpn-digital/py-pkgversion?branch=master\n\n.. image:: https://img.shields.io/codecov/c/github/kpn-digital/py-pkgversion/master.svg\n    :target: http://codecov.io/github/kpn-digital/py-pkgversion?branch=master\n\n.. image:: https://img.shields.io/pypi/v/pkgversion.svg\n    :target: https://pypi.python.org/pypi/pkgversion\n\n.. image:: https://readthedocs.org/projects/py-pkgversion/badge/?version=latest\n    :target: http://py-pkgversion.readthedocs.org/en/latest/?badge=latest\n\n\nVersioning utils for python projects\n', 'url': 'https://github.com/kpn-digital/py-pkgversion', 'version': '1.0.3+3.g6154f4d', 'zip_safe': False, 'install_requires': [], 'packages': ['pkgversion'], 'classifiers': ['Development Status :: 5 - Production/Stable', 'Environment :: Web Environment', 'Intended Audience :: Developers', 'Operating System :: OS Independent', 'Programming Language :: Python', 'Programming Language :: Python :: 2', 'Programming Language :: Python :: 2.7', 'Programming Language :: Python :: 3', 'Programming Language :: Python :: 3.5', 'Topic :: Internet :: WWW/HTTP'], 'tests_require': ['tox'], 'description': 'Versioning utils for python projects'})
+setup(**{'author': 'Niels Lensink',
+ 'author_email': 'niels@elements.nl',
+ 'classifiers': ['Development Status :: 5 - Production/Stable',
+                 'Environment :: Web Environment',
+                 'Intended Audience :: Developers',
+                 'Operating System :: OS Independent',
+                 'Programming Language :: Python',
+                 'Programming Language :: Python :: 2',
+                 'Programming Language :: Python :: 2.7',
+                 'Programming Language :: Python :: 3',
+                 'Programming Language :: Python :: 3.7',
+                 'Programming Language :: Python :: 3.8',
+                 'Topic :: Internet :: WWW/HTTP'],
+ 'description': 'Versioning utils for python projects',
+ 'include_package_data': True,
+ 'install_requires': [],
+ 'long_description': 'Python pkgversion\n'
+                     '=================\n'
+                     '\n'
+                     '.. image:: '
+                     'https://secure.travis-ci.org/kpn-digital/py-pkgversion.svg?branch=master\n'
+                     '    :target:  '
+                     'http://travis-ci.org/kpn-digital/py-pkgversion?branch=master\n'
+                     '\n'
+                     '.. image:: '
+                     'https://img.shields.io/codecov/c/github/kpn-digital/py-pkgversion/master.svg\n'
+                     '    :target: '
+                     'http://codecov.io/github/kpn-digital/py-pkgversion?branch=master\n'
+                     '\n'
+                     '.. image:: https://img.shields.io/pypi/v/pkgversion.svg\n'
+                     '    :target: https://pypi.python.org/pypi/pkgversion\n'
+                     '\n'
+                     '.. image:: '
+                     'https://readthedocs.org/projects/py-pkgversion/badge/?version=latest\n'
+                     '    :target: '
+                     'http://py-pkgversion.readthedocs.org/en/latest/?badge=latest\n'
+                     '\n'
+                     '\n'
+                     'Versioning utils for python projects\n',
+ 'name': 'pkgversion',
+ 'packages': ['pkgversion'],
+ 'tests_require': ['tox'],
+ 'url': 'https://github.com/kpn-digital/py-pkgversion',
+ 'version': '3.0.2+1.g578d983',
+ 'zip_safe': False})

--- a/setup_gen.py
+++ b/setup_gen.py
@@ -25,7 +25,8 @@ write_setup_py(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Internet :: WWW/HTTP',
     ]
 )

--- a/tests/test_pkgversion.py
+++ b/tests/test_pkgversion.py
@@ -97,7 +97,7 @@ class TestPkgversion(object):
                 Popen(command, stdout=PIPE, cwd=str(tmpdir)).communicate()
 
             expected_import = "^from setuptools import setup$"
-            expected_setup = "^setup\(\*\*(.*)\)$"
+            expected_setup = "^setup\(\*\*(.*)\)$"  # noqa: W605
 
             write_setup_py(
                 install_requires=['test']

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,8 @@ addopts=--tb=short
 [tox]
 envlist =
     py27-{pip9,pip10}
-    py35-{pip9,pip10}
-    py36-{pip9,pip10}
+    py37-{pip9,pip10}
+    py38-pip20
     cov
     isort-check
     isort-fix
@@ -14,68 +14,52 @@ envlist =
 
 skipsdist = true
 
+[testenv]
 basepython =
-    py27-{pip9,pip10}: python2.7
-    py35-{pip9,pip10}: python3.5
-    py36-{pip9,pip10}: python3.6
-    cov: python3.6
+    py27: python2.7
+    py37: python3.7
+    py38: python3.8
+    cov: python3.8
 deps =
     -rrequirements/requirements-base.txt
     -rrequirements/requirements-testing.txt
+    pip9: pip<10.0
+    pip10: pip<11.0
+    pip20: pip<21.0
+commands =
+     py.test tests
 
 [testenv:cov]
-basepython= python3.6
+basepython= python3.8
 commands =
     py.test tests --cov-report=term-missing --cov-append --cov=pkgversion --cov-report xml {posargs}
 deps =
     -rrequirements/requirements-base.txt
     -rrequirements/requirements-testing.txt
 
-[general]
-commands =
-     py.test tests
-deps =
-    -rrequirements/requirements-base.txt
-    -rrequirements/requirements-testing.txt
-
-[testenv:py27-{pip9,pip10}]
-basepython = python2.7
-commands =
-    {[general]commands}
-
-[testenv:py35-{pip9,pip10}]
-basepython = python3.5
-commands =
-   {[general]commands}
-
-[testenv:py36-{pip9,pip10}]
-basepython = python3.6
-commands =
-    {[general]commands}
-
 ##
 # Flake8 linting
 ##
 
 [testenv:lint]
-basepython = python3.6
+basepython = python3.8
 commands = flake8 pkgversion tests --exclude=pkgversion/__init__.py
 deps =
     flake8
 
 [testenv:docs]
-basepython = python3.6
+basepython = python3.8
 commands = sphinx-build -W -b html {toxinidir}/docs {toxinidir}/docs/_build/html
 deps =
     -rrequirements/requirements-testing.txt
 
 [testenv:isort-check]
-basepython = python3.6
+basepython = python3.8
 commands = isort -rc -c pkgversion tests
 deps = isort
 
 [testenv:isort-fix]
-basepython = python3.6
+basepython = python3.8
 commands = isort -rc pkgversion tests
 deps = isort
 


### PR DESCRIPTION
Apparently, the tests did not run since the
testenv did not match, so the builds were green
no matter the code.

I changed the tox.ini and added py38-pip20 and
made sure it failed before fixing the imports
in pkgversion.py.

On another note, we should probably not use
internals like this because it will randomly
break (like now). Fixing it now so we are
unblocked at least.